### PR TITLE
improvements for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ WORKDIR /qless
 
 RUN bundle install
 
-# make jquery local
+# make jquery local, can be removed once https://github.com/seomoz/qless/issues/244 is resolved
 RUN curl -o "$(find /var/lib/gems/ -wholename */lib/qless/server/static/js -type d)/jquery.min.js" https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js && \
   patch -d "$(find /var/lib/gems/ -wholename */lib/qless/server -type d)" -p4 < /qless/local_js.patch

--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ application.
 When you want to run the container, you'll need to pass two environment
 variables to `docker run ...` to successfully start the container:
 
-1. `REDIS_HOST`: The host which is running the redis instance you want
-   to connect to. E.g. `www.example.com`
-2. `REDIS_PORT`: The port on the host which is running redis. E.g.
-   `6379`.
-3. `HTTP_PATH`: The path that the web app will be listening on. E.g.
+1. `REDIS_URL`: e.g. `redis://some-host:7000/3`
+   or alternative those 3:
+   1. `REDIS_HOST`: The host which is running the redis instance you want
+      to connect to. E.g. `www.example.com`
+   1. `REDIS_PORT`: The port on the host which is running redis. E.g.
+      `6379`.
+   1. `DB_NUM`: The redis DB number that the app will connect to.  Defaults
+      to 0.
+1. `HTTP_PATH`: Optional, the path that the web app will be listening on. default
    `/qless`
-4. `DB_NUM`: The redis DB number that the app will connect to.  Defaults
-   to 0.
 
 You will then run `bundle exec rackup qless.ru -o0.0.0.0 -p 9001` on the
 docker container to run a the qless web app and expose it on port 9001.
@@ -37,6 +39,8 @@ An example way of running the docker container is to run:
 
 ```bash
 docker run -d --net="host" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6379" -e "HTTP_PATH=\/qless" <docker_image> bundle exec rackup qless.ru -o0.0.0.0 -p 9001
+# or
+docker run -e REDIS_URL="redis://127.0.0.1:6379/0" <docker_image> bundle exec rackup qless.ru -o0.0.0.0 -p 5678
 ```
 
 To run the docker container connecting to a specific redis database use:

--- a/local_js.patch
+++ b/local_js.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/qless/server/views/layout.erb b/lib/qless/server/views/layout.erb
+index cb41fb6..9ac8747 100644
+--- a/lib/qless/server/views/layout.erb
++++ b/lib/qless/server/views/layout.erb
+@@ -12,7 +12,7 @@
+     <link href="<%= u '/css/docs.css' %>" rel="stylesheet">
+     <link href="<%= u '/css/jquery.noty.css' %>" rel="stylesheet">
+     <link href="<%= u '/css/noty_theme_twitter.css' %>" rel="stylesheet">
+-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
++    <script src="<%= u '/js/jquery.min.js' %>" type="text/javascript"></script>
+ 
+     <style type="text/css">
+     body {

--- a/qless.ru
+++ b/qless.ru
@@ -2,7 +2,12 @@ require 'qless'
 require 'qless/server'
 
 # use REDIS_URL="redis://some-host:7000/3"
-client = Qless::Client.new
+
+if ENV['REDIS_URL']
+  client = Qless::Client.new
+else
+  client = Qless::Client.new(:host => ENV['REDIS_HOST'], :port => ENV['REDIS_PORT'].to_i, :db => ENV['DB_NUM'].to_i )
+end
 
 QlessServer = Rack::Builder.app do
   if ENV['QLESS_BASIC_AUTH_USER'] && ENV['QLESS_BASIC_AUTH_PASSWORD']
@@ -11,10 +16,7 @@ QlessServer = Rack::Builder.app do
     end
   end
 
-  gui_path = '/qless'
-  if ENV['HTTP_PATH']
-    gui_path = ENV['HTTP_PATH']
-  end
+  gui_path = ENV.fetch('HTTP_PATH', '/qless')
 
   map(gui_path) { run Qless::Server.new(client) }
 end

--- a/qless.ru
+++ b/qless.ru
@@ -1,7 +1,8 @@
 require 'qless'
 require 'qless/server'
 
-client = Qless::Client.new(:host => ENV['REDIS_HOST'], :port => ENV['REDIS_PORT'].to_i, :db => ENV['DB_NUM'].to_i )
+# use REDIS_URL="redis://some-host:7000/3"
+client = Qless::Client.new
 
 QlessServer = Rack::Builder.app do
   if ENV['QLESS_BASIC_AUTH_USER'] && ENV['QLESS_BASIC_AUTH_PASSWORD']
@@ -10,7 +11,12 @@ QlessServer = Rack::Builder.app do
     end
   end
 
-  map(ENV['HTTP_PATH']) { run Qless::Server.new(client) }
+  gui_path = '/qless'
+  if ENV['HTTP_PATH']
+    gui_path = ENV['HTTP_PATH']
+  end
+
+  map(gui_path) { run Qless::Server.new(client) }
 end
 
 run QlessServer


### PR DESCRIPTION
I used your Dockerfile as a base, key changes:

- to run it you now use `REDIS_URL` instead of 3 env vars, and `HTTP_PATH` env var is now optional (default being '/qless') example: `docker run -e REDIS_URL="redis://127.0.0.1:6379/0" $IMG_NAME bundle exec rackup qless.ru -o0.0.0.0 -p 5678`
- Dockerfile is according to dockers best practices (fewer RUN commands)
- final image is about 110 MiB smaller than ubuntu based prior version
- jquery is no longer loaded from CDN (in our environment that doesn't work, client computers interacting with cluster have no internet access) bug seomoz/qless#244 references that problem too

I hope some of those changes make into your master.