### PR TITLE
Fix commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ variables to `docker run ...` to successfully start the container:
 An example way of running the docker container is to run:
 
 ```bash
-docker run -d --net="host" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6379" -e "HTTP_PATH=\/qless" seomoz/qless-ui
+docker run -d --net="host" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6379" -e "HTTP_PATH=/qless" seomoz/qless-ui
 # or
 docker run -e REDIS_URL="redis://127.0.0.1:6379/0" seomoz/qless-ui
 ```
@@ -50,7 +50,7 @@ docker run -e REDIS_URL="redis://127.0.0.1:6379/0" seomoz/qless-ui
 To run the docker container connecting to a specific redis database use:
 
 ```bash
-docker run -d --net="host" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6379" -e "HTTP_PATH=\/qless"  -e "DB_NUM=15" seomoz/qless-ui
+docker run -d --net="host" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6379" -e "HTTP_PATH=/qless" -e "DB_NUM=15" seomoz/qless-ui
 ```
 
 Assuming that the docker container is running on `localhost`, then to


### PR DESCRIPTION
@b4hand 

remove stray backslash.

```
$ docker run --rm -it --net="host" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6379" -e "HTTP_PATH=\/qless" seomoz/qless-ui
bundler: failed to load command: rackup (/usr/local/bundle/bin/rackup)
ArgumentError: paths need to start with /
  /usr/local/bundle/gems/rack-2.0.3/lib/rack/urlmap.rb:31:in `block in remap'
...
```
:disappointed: 

:arrow_right: 

```
$ docker run --rm -it --net="host" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6379" -e "HTTP_PATH=/qless" seomoz/qless-ui
Thin web server (v1.7.2 codename Bachmanity)
Maximum connections set to 1024
Listening on 0.0.0.0:9000, CTRL+C to stop
```

:smile: 