### PR TITLE
Upgrade qless to v0.15.0 for Valkey compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ruby:2.4.2-slim-stretch
+FROM ruby:3.1-slim-bookworm
 
 # Prevent docker's default encoding of ASCII.
 # # https://oncletom.io/2015/docker-encoding/
-ENV LANG C.UTF-8
-ENV LANGUAGE en_US:C
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=en_US:C
+ENV LC_ALL=C.UTF-8
 
 RUN apt-get update && \
  apt-get install -y build-essential git curl redis-tools && \

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gem 'rack'
 # TODO: see why this isn't included in qless, though it is listed as a development dependency in
 # https://github.com/seomoz/qless/blob/master/qless.gemspec
 gem 'sinatra'
-gem 'qless', git: 'https://github.com/seomoz/qless.git'
+gem 'qless', '0.15.0', git: 'https://github.com/seomoz/qless.git', tag: 'v0.15.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,64 +1,66 @@
 GIT
   remote: https://github.com/seomoz/qless.git
-  revision: 9585ffd75d4fb9bda0a0275088c9f3c595328839
+  revision: 4a77d54fddb3a315c3da9f71f90b9915af3bf247
+  tag: v0.15.0
   specs:
-    qless (0.11.0)
-      metriks (~> 0.9)
-      redis (>= 2.2, < 4.0.0.rc1)
+    qless (0.15.0)
+      redis (>= 2.2, < 5)
       rusage (~> 0.2.0)
       sentry-raven (~> 0.15.6)
       sinatra (>= 1.3, < 2.1)
       statsd-ruby (~> 1.3)
       thin (~> 1.6)
-      thor (~> 0.19.1)
+      thor (~> 0.19)
       vegas (~> 0.1.11)
 
 GEM
   remote: https://www.rubygems.org/
   specs:
-    atomic (1.1.99)
-    avl_tree (1.2.1)
-      atomic (~> 1.1)
-    daemons (1.2.5)
-    eventmachine (1.2.5)
-    faraday (0.13.1)
-      multipart-post (>= 1.2, < 3)
-    hitimes (1.2.6)
-    metriks (0.9.9.8)
-      atomic (~> 1.0)
-      avl_tree (~> 1.2.0)
-      hitimes (~> 1.1)
-    multipart-post (2.0.0)
-    mustermann (1.0.1)
-    rack (2.0.3)
-    rack-protection (2.0.0)
+    daemons (1.4.1)
+    eventmachine (1.2.7)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    json (2.19.3)
+    logger (1.7.0)
+    mustermann (1.1.2)
+      ruby2_keywords (~> 0.0.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    rack (2.2.22)
+    rack-protection (2.0.8.1)
       rack
-    redis (3.3.5)
+    redis (4.8.1)
+    ruby2_keywords (0.0.5)
     rusage (0.2.0)
     sentry-raven (0.15.6)
       faraday (>= 0.7.6)
-    sinatra (2.0.0)
+    sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
-    statsd-ruby (1.4.0)
-    thin (1.7.2)
+    statsd-ruby (1.5.0)
+    thin (1.8.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thor (0.19.4)
-    tilt (2.0.8)
+    thor (0.20.3)
+    tilt (2.7.0)
+    uri (1.1.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
 
 PLATFORMS
-  ruby
+  aarch64-linux
 
 DEPENDENCIES
-  qless!
+  qless (= 0.15.0)!
   rack
   sinatra
 
 BUNDLED WITH
-   1.14.5
+   2.3.27


### PR DESCRIPTION
###  Problem
After upgrading ElastiCache from `Redis 5.0.6` to `Valkey 8.2` in Feedstore repo (https://github.com/seomoz/feedstore/pull/1253), the qless-ui dashboard was crash-looping with `NOSCRIPT No matching script` errors. The existing ECR image (`latest`, from 2020) used an old qless Ruby gem that didn't handle Valkey's flushed Lua script cache.

### Solution
- Updated `Gemfile` to pin qless to v0.15.0 (adds Valkey 8 support) in `qless-docker` repo
- Updated `Dockerfile` base image from `ruby:2.4.2-slim-stretch` to `ruby:3.1-slim-bookworm` (Stretch is EOL, builds were failing)
- Removed stale `Gemfile.lock` (was pinned to qless 0.11.0)

## How this was tested
Pushed `1.3.0` and `latest tags` to `ECR (594715671849.dkr.ecr.us-east-1.amazonaws.com/qless-ui)`
Force-restarted ECS service in `Feedstore` repo:
```
aws ecs update-service --cluster feedstore-write \
  --service data-platform-dev-feedstore-write-qless \
  --force-new-deployment
```

### Verification:
[x] Qless UI loads at feedstore-write-qless.data-platform-dev.aws.moz.com/qless
[x]  No NOSCRIPT errors
[x] Workers connected and processing jobs

